### PR TITLE
Feature/unity version check

### DIFF
--- a/UnityEngineAnalyzer.CLI/AnalyzerReport.cs
+++ b/UnityEngineAnalyzer.CLI/AnalyzerReport.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.CodeAnalysis;
 using UnityEngineAnalyzer.CLI.Reporting;
 
@@ -52,9 +51,9 @@ namespace UnityEngineAnalyzer.CLI
                     FileName = fileName,
                     LineNumber = lineNumber,
                     CharacterPosition = characterPosition,
-                    Severity = (DiagnosticInfo.DiagnosticInfoSeverity)diagnostic.Severity
+                    Severity = (DiagnosticInfo.DiagnosticInfoSeverity)diagnostic.Severity,
+                    VersionSpan = DiagnosticDescriptors.GetVersion(diagnostic.Descriptor)
                 };
-
 
                 foreach (var exporter in _exporters)
                 {
@@ -71,11 +70,11 @@ namespace UnityEngineAnalyzer.CLI
             }
         }
 
-        public void InitializeReport(FileInfo projectFile)
+        public void InitializeReport(Options options)
         {
             foreach (var exporter in _exporters)
             {
-                exporter.InitializeExporter(projectFile);       
+                exporter.InitializeExporter(options);
             }
         }
 

--- a/UnityEngineAnalyzer.CLI/Options.cs
+++ b/UnityEngineAnalyzer.CLI/Options.cs
@@ -1,10 +1,10 @@
 ﻿using CommandLine;
 using System.Collections.Generic;
-using UnityEngineAnalyzer.CLI.Reporting;
+using static UnityEngineAnalyzer.CLI.Reporting.DiagnosticInfo;
 
 namespace UnityEngineAnalyzer.CLI
 {
-    internal class Options
+    public class Options
     {
         [ValueOption(0)]
         public string ProjectFile { get; set; }
@@ -15,7 +15,10 @@ namespace UnityEngineAnalyzer.CLI
         [Option('c', "configuration", HelpText = "Custom json configuration to be used.")]
         public string ConfigurationFile { get; set; }
 
-        [Option('s', "severity", DefaultValue = DiagnosticInfo.DiagnosticInfoSeverity.Warning, HelpText = "Minimal severity to be reported.")]
-        public DiagnosticInfo.DiagnosticInfoSeverity MinimalSeverity { get; set; }
+        [Option('s', "severity", DefaultValue = DiagnosticInfoSeverity.Warning, HelpText = "Minimal severity to be reported.")]
+        public DiagnosticInfoSeverity MinimalSeverity { get; set; }
+
+        [Option('v', "version", DefaultValue = UnityVersion.NONE, HelpText = "Check against spesific Unity version.")]
+        public UnityVersion Version { get; set; }
     }
 }

--- a/UnityEngineAnalyzer.CLI/Program.cs
+++ b/UnityEngineAnalyzer.CLI/Program.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngineAnalyzer.CLI.Reporting;
 
@@ -11,7 +9,6 @@ namespace UnityEngineAnalyzer.CLI
     public class Program
     {
         private static readonly Dictionary<string, Type> AvailableExporters = new Dictionary<string, Type>();
-        private const UnityVersion DEFAULT_UNITY_VERSION = UnityVersion.LATEST;
 
         static Program()
         {
@@ -32,7 +29,8 @@ namespace UnityEngineAnalyzer.CLI
                     return;
                 }
 
-                options.Version = DefineUnityVersion(options);
+                var unityVersionResolver = new UnityVersionResolver();
+                options.Version = unityVersionResolver.ResolveVersion(options);
 
                 var startTime = DateTime.Now;
 
@@ -95,45 +93,6 @@ namespace UnityEngineAnalyzer.CLI
         }
 
         //TODO SET TO OWN CLASS
-        private static UnityVersion DefineUnityVersion(Options options)
-        {
-            if (options.Version != UnityVersion.NONE)
-            {
-                return options.Version;
-            }
 
-            //THIS ONLY WORKS ON UNITY >= 5, before that ProjectVersion.txt did not exists
-            var projectPath = new FileInfo(options.ProjectFile).Directory;
-            var projectVersionFile = new FileInfo(projectPath + "/ProjectSettings/ProjectVersion.txt");
-            if (projectVersionFile.Exists)
-            {
-                var projectVersionString = File.ReadAllText(projectVersionFile.FullName);
-                return TryParseUnityVersion(projectVersionString);
-            }
-
-            return DEFAULT_UNITY_VERSION;
-        }
-
-        //TODO UNIT TESTS
-        private static UnityVersion TryParseUnityVersion(string version)
-        {
-            string editorText = "m_EditorVersion: ";
-            var match = Regex.Match(version, editorText + "[0-9.a-z]*");
-
-            string src = match.Value.Substring(editorText.Length);
-            src = src.Replace('.', '_');
-            src = src.Substring(0, src.IndexOf('_') + 2);
-
-            var unityVersions = Enum.GetValues(typeof(UnityVersion)).Cast<UnityVersion>();
-            foreach (var unityVersion in unityVersions)
-            {
-                if (Enum.GetName(typeof(UnityVersion), unityVersion).Contains(src))
-                {
-                    return unityVersion;
-                }
-            }
-
-            return DEFAULT_UNITY_VERSION;
-        }
     }
 }

--- a/UnityEngineAnalyzer.CLI/Reporting/AnalyzerExporter.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/AnalyzerExporter.cs
@@ -1,16 +1,36 @@
-﻿using System;
+﻿using Microsoft.CodeAnalysis;
+using System;
 using System.IO;
+using static UnityEngineAnalyzer.CLI.Reporting.DiagnosticInfo;
 
 namespace UnityEngineAnalyzer.CLI.Reporting
 {
     public abstract class AnalyzerExporter : IAnalyzerExporter
     {
-        //NOTE: Can we use using.static.DiagnosticsInfo; C#6 feature?
-        protected DiagnosticInfo.DiagnosticInfoSeverity MinimalSeverity;
+        protected DiagnosticInfoSeverity MinimalSeverity;
+        private readonly UnityVersion unityVersion;
 
-        public AnalyzerExporter(DiagnosticInfo.DiagnosticInfoSeverity MinimalSeverity)
+        public AnalyzerExporter(DiagnosticInfoSeverity MinimalSeverity, UnityVersion unityVersion)
         {
             this.MinimalSeverity = MinimalSeverity;
+            this.unityVersion = unityVersion;
+        }
+
+        public bool AbleToAnalyzer(DiagnosticInfoSeverity currentSeverity, DiagnosticDescriptor diagnosticInfo, UnityVersion unityVersion = UnityVersion.ALL)
+        {
+            if (MinimalSeverity < currentSeverity)
+            {
+                return false;
+            }
+
+            var off = DiagnosticDescriptors.GetVersion(diagnosticInfo);
+
+            if (unityVersion < off.Item1 || unityVersion > off.Item2)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public abstract void AppendDiagnostic(DiagnosticInfo diagnosticInfo);

--- a/UnityEngineAnalyzer.CLI/Reporting/AnalyzerExporter.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/AnalyzerExporter.cs
@@ -1,31 +1,24 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
-using System.IO;
-using static UnityEngineAnalyzer.CLI.Reporting.DiagnosticInfo;
+﻿using System;
 
 namespace UnityEngineAnalyzer.CLI.Reporting
 {
     public abstract class AnalyzerExporter : IAnalyzerExporter
     {
-        protected DiagnosticInfoSeverity MinimalSeverity;
-        private readonly UnityVersion unityVersion;
+        private readonly Options options;
 
-        public AnalyzerExporter(DiagnosticInfoSeverity MinimalSeverity, UnityVersion unityVersion)
+        public AnalyzerExporter(Options options)
         {
-            this.MinimalSeverity = MinimalSeverity;
-            this.unityVersion = unityVersion;
+            this.options = options;
         }
 
-        public bool AbleToAnalyzer(DiagnosticInfoSeverity currentSeverity, DiagnosticDescriptor diagnosticInfo, UnityVersion unityVersion = UnityVersion.ALL)
+        public bool IsAnalyzerRelevant(DiagnosticInfo diagnosticInfo)
         {
-            if (MinimalSeverity < currentSeverity)
+            if (options.MinimalSeverity > diagnosticInfo.Severity)
             {
                 return false;
             }
 
-            var off = DiagnosticDescriptors.GetVersion(diagnosticInfo);
-
-            if (unityVersion < off.Item1 || unityVersion > off.Item2)
+            if (options.Version < diagnosticInfo.VersionSpan.First || options.Version > diagnosticInfo.VersionSpan.Last)
             {
                 return false;
             }
@@ -35,7 +28,7 @@ namespace UnityEngineAnalyzer.CLI.Reporting
 
         public abstract void AppendDiagnostic(DiagnosticInfo diagnosticInfo);
         public abstract void FinalizeExporter(TimeSpan duration);
-        public abstract void InitializeExporter(FileInfo projectFile);
+        public abstract void InitializeExporter(Options options);
         public abstract void NotifyException(Exception exception);
     }
 }

--- a/UnityEngineAnalyzer.CLI/Reporting/ConsoleAnalyzerExporter.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/ConsoleAnalyzerExporter.cs
@@ -1,11 +1,10 @@
 using System;
-using System.IO;
 
 namespace UnityEngineAnalyzer.CLI.Reporting
 {
     public class ConsoleAnalyzerExporter : StandardOutputAnalyzerReporter
     {
-        public ConsoleAnalyzerExporter(DiagnosticInfo.DiagnosticInfoSeverity MinimalSeverity) : base(MinimalSeverity)
+        public ConsoleAnalyzerExporter(Options options) : base(options)
         {
         }
 
@@ -19,12 +18,13 @@ namespace UnityEngineAnalyzer.CLI.Reporting
             Console.ReadKey();
         }
 
-        public override void InitializeExporter(FileInfo projectFile)
+        public override void InitializeExporter(Options options)
         {
             Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine("Unity Syntax Analyzer");
             Console.WriteLine();
-            Console.WriteLine("Analyzing: {0}", projectFile.FullName);
+            Console.WriteLine("Analyzing: {0}", options.ProjectFile);
+            Console.WriteLine("With Unity version: " + Enum.GetName((typeof(UnityVersion)), options.Version));
             Console.WriteLine();
             Console.ResetColor();
         }

--- a/UnityEngineAnalyzer.CLI/Reporting/DiagnosticInfo.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/DiagnosticInfo.cs
@@ -10,6 +10,7 @@ namespace UnityEngineAnalyzer.CLI.Reporting
         public int LineNumber { get; set; }
         public int CharacterPosition { get; set; }
         public DiagnosticInfoSeverity Severity { get; set; }
+        public UnityVersionSpan VersionSpan { get; set; }
 
         public enum DiagnosticInfoSeverity
         {

--- a/UnityEngineAnalyzer.CLI/Reporting/IAnalyzerExporter.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/IAnalyzerExporter.cs
@@ -7,7 +7,7 @@ namespace UnityEngineAnalyzer.CLI.Reporting
     {
         void AppendDiagnostic(DiagnosticInfo diagnosticInfo);
         void FinalizeExporter(TimeSpan duration);
-        void InitializeExporter(FileInfo projectFile);
+        void InitializeExporter(Options options);
         void NotifyException(Exception exception);
     }
 }

--- a/UnityEngineAnalyzer.CLI/Reporting/JsonAnalyzerExporter.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/JsonAnalyzerExporter.cs
@@ -15,13 +15,13 @@ namespace UnityEngineAnalyzer.CLI.Reporting
         private readonly List<Exception> _exceptions = new List<Exception>();
         private string _destinationReportFile;
 
-        public JsonAnalyzerExporter(DiagnosticInfo.DiagnosticInfoSeverity MinimalSeverity) : base(MinimalSeverity)
+        public JsonAnalyzerExporter(Options options) : base(options)
         {
         }
 
         public override void AppendDiagnostic(DiagnosticInfo diagnosticInfo)
         {
-            if (diagnosticInfo.Severity >= MinimalSeverity)
+            if (IsAnalyzerRelevant(diagnosticInfo))
             {
                 _jsonSerializer.Serialize(_jsonWriter, diagnosticInfo);
             }
@@ -50,8 +50,9 @@ namespace UnityEngineAnalyzer.CLI.Reporting
             //Process.Start(_destinationReportFile);
         }
 
-        public override void InitializeExporter(FileInfo projectFile)
+        public override void InitializeExporter(Options options)
         {
+            var projectFile = new FileInfo(options.ProjectFile);
             if (!projectFile.Exists)
             {
                 throw new ArgumentException("Project file does not exist");

--- a/UnityEngineAnalyzer.CLI/Reporting/StandardOutputAnalyzerReporter.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/StandardOutputAnalyzerReporter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using static UnityEngineAnalyzer.CLI.Reporting.DiagnosticInfo;
 
 namespace UnityEngineAnalyzer.CLI.Reporting
@@ -9,13 +8,13 @@ namespace UnityEngineAnalyzer.CLI.Reporting
         protected const string ConsoleSeparator = "\t";
         protected const string FailurePrefix = "# ";
 
-        public StandardOutputAnalyzerReporter(DiagnosticInfoSeverity MinimalSeverity, UnityVersion unityVersion) : base(MinimalSeverity, unityVersion)
+        public StandardOutputAnalyzerReporter(Options options) : base(options)
         {
         }
 
         public override void AppendDiagnostic(DiagnosticInfo diagnosticInfo)
         {
-            if (AbleToAnalyzer(MinimalSeverity, diagnosticInfo) == false)
+            if (IsAnalyzerRelevant(diagnosticInfo) == false)
             {
                 return;
             }
@@ -37,13 +36,13 @@ namespace UnityEngineAnalyzer.CLI.Reporting
         {
             switch (severity)
             {
-                case DiagnosticInfo.DiagnosticInfoSeverity.Hidden:
+                case DiagnosticInfoSeverity.Hidden:
                     return ConsoleColor.Gray;
-                case DiagnosticInfo.DiagnosticInfoSeverity.Info:
+                case DiagnosticInfoSeverity.Info:
                     return ConsoleColor.Green;
-                case DiagnosticInfo.DiagnosticInfoSeverity.Warning:
+                case DiagnosticInfoSeverity.Warning:
                     return ConsoleColor.Yellow;
-                case DiagnosticInfo.DiagnosticInfoSeverity.Error:
+                case DiagnosticInfoSeverity.Error:
                     return ConsoleColor.Red;
                 default:
                     return ConsoleColor.White;
@@ -71,7 +70,7 @@ namespace UnityEngineAnalyzer.CLI.Reporting
         {
         }
 
-        public override void InitializeExporter(FileInfo projectFile)
+        public override void InitializeExporter(Options options)
         {
         }
     }

--- a/UnityEngineAnalyzer.CLI/Reporting/StandardOutputAnalyzerReporter.cs
+++ b/UnityEngineAnalyzer.CLI/Reporting/StandardOutputAnalyzerReporter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using static UnityEngineAnalyzer.CLI.Reporting.DiagnosticInfo;
 
 namespace UnityEngineAnalyzer.CLI.Reporting
 {
@@ -8,13 +9,13 @@ namespace UnityEngineAnalyzer.CLI.Reporting
         protected const string ConsoleSeparator = "\t";
         protected const string FailurePrefix = "# ";
 
-        public StandardOutputAnalyzerReporter(DiagnosticInfo.DiagnosticInfoSeverity MinimalSeverity) : base(MinimalSeverity)
+        public StandardOutputAnalyzerReporter(DiagnosticInfoSeverity MinimalSeverity, UnityVersion unityVersion) : base(MinimalSeverity, unityVersion)
         {
         }
 
         public override void AppendDiagnostic(DiagnosticInfo diagnosticInfo)
         {
-            if (diagnosticInfo.Severity < MinimalSeverity)
+            if (AbleToAnalyzer(MinimalSeverity, diagnosticInfo) == false)
             {
                 return;
             }
@@ -30,10 +31,9 @@ namespace UnityEngineAnalyzer.CLI.Reporting
             Console.Write(diagnosticInfo.Message);
             Console.ResetColor();
             Console.WriteLine(@"{0}{1}{0}{2},{3}", ConsoleSeparator,diagnosticInfo.FileName, diagnosticInfo.LineNumber, diagnosticInfo.CharacterPosition);
-            
         }
 
-        private ConsoleColor ConsoleColorFromSeverity(DiagnosticInfo.DiagnosticInfoSeverity severity)
+        private ConsoleColor ConsoleColorFromSeverity(DiagnosticInfoSeverity severity)
         {
             switch (severity)
             {

--- a/UnityEngineAnalyzer.CLI/UnityEngineAnalyzer.CLI.csproj
+++ b/UnityEngineAnalyzer.CLI/UnityEngineAnalyzer.CLI.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reporting\StandardOutputAnalyzerReporter.cs" />
     <Compile Include="SolutionAnalyzer.cs" />
+    <Compile Include="UnityVersionResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/UnityEngineAnalyzer.CLI/UnityVersionResolver.cs
+++ b/UnityEngineAnalyzer.CLI/UnityVersionResolver.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace UnityEngineAnalyzer.CLI
+{
+    //NOTE: This class would benefit from UnitTests specially: TryParseUnityVersion
+    internal class UnityVersionResolver
+    {
+        private const UnityVersion DEFAULT_UNITY_VERSION = UnityVersion.LATEST;
+
+        public UnityVersion ResolveVersion(Options options)
+        {
+            if (options.Version != UnityVersion.NONE)
+            {
+                return options.Version;
+            }
+
+            //THIS ONLY WORKS ON UNITY >= 5, before that ProjectVersion.txt did not exists
+            if (ResolveProjectVersionFilePath(options) != null)
+            {
+                var projectVersionString = File.ReadAllText(ResolveProjectVersionFilePath(options));
+                return TryParseUnityVersion(projectVersionString);
+            }
+
+            return DEFAULT_UNITY_VERSION;
+        }
+
+        private string ResolveProjectVersionFilePath(Options options)
+        {
+            var projectPath = new FileInfo(options.ProjectFile).Directory;
+            var path = Path.Combine(projectPath.FullName, "ProjectSettings", "ProjectVersion.txt");
+            var projectVersionFile = new FileInfo(path);
+
+            if (projectVersionFile.Exists)
+            {
+                return projectVersionFile.FullName;
+            }
+
+            return null;
+        }
+
+        private UnityVersion TryParseUnityVersion(string version)
+        {
+            string editorText = "m_EditorVersion: ";
+            var match = Regex.Match(version, editorText + "[0-9.a-z]*");
+
+            string src = match.Value.Substring(editorText.Length);
+            src = src.Replace('.', '_');
+            src = src.Substring(0, src.IndexOf('_') + 2);
+
+            var unityVersions = Enum.GetValues(typeof(UnityVersion)).Cast<UnityVersion>();
+            foreach (var unityVersion in unityVersions)
+            {
+                if (Enum.GetName(typeof(UnityVersion), unityVersion).Contains(src))
+                {
+                    return unityVersion;
+                }
+            }
+
+            return DEFAULT_UNITY_VERSION;
+        }
+    }
+}

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticDescriptors.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticDescriptors.cs
@@ -55,11 +55,11 @@ namespace UnityEngineAnalyzer
             InvokeFunctionMissing = CreateDiagnosticDescriptor<InvokeFunctionMissingResources>(DiagnosticIDs.InvokeFunctionMissing, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
             DoNotUseStateName = CreateDiagnosticDescriptor<DoNotUseStateNameResource>(DiagnosticIDs.DoNotUseStateNameInAnimator, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
             DoNotUseStringPropertyNames = CreateDiagnosticDescriptor<DoNotUseStringPropertyNamesResource>(DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
-            UseNonAllocMethods = CreateDiagnosticDescriptor<UseNonAllocMethodsResources>(DiagnosticIDs.PhysicsUseNonAllocMethods, DiagnosticCategories.GC, DiagnosticSeverity.Warning);
+            UseNonAllocMethods = CreateDiagnosticDescriptor<UseNonAllocMethodsResources>(DiagnosticIDs.PhysicsUseNonAllocMethods, DiagnosticCategories.GC, DiagnosticSeverity.Warning, UnityVersion.UNITY_5_3);
             CameraMainIsSlow = CreateDiagnosticDescriptor<CameraMainResource>(DiagnosticIDs.CameraMainIsSlow, DiagnosticCategories.GC, DiagnosticSeverity.Warning);
         }
 
-        private static DiagnosticDescriptor CreateDiagnosticDescriptor<T>(string id, string category, DiagnosticSeverity severity, UnityVersion latest = UnityVersion.ALL, bool isEnabledByDefault = true)
+        private static DiagnosticDescriptor CreateDiagnosticDescriptor<T>(string id, string category, DiagnosticSeverity severity, UnityVersion first = UnityVersion.UNITY_1_0, UnityVersion latest = UnityVersion.LATEST, bool isEnabledByDefault = true)
         {
             var resourceManager = new ResourceManager(typeof(T));
 
@@ -70,7 +70,7 @@ namespace UnityEngineAnalyzer
             category: category,
             defaultSeverity: severity,
             isEnabledByDefault: isEnabledByDefault,
-            customTags: CreateUnityVersionInfo(latest, latest),
+            customTags: CreateUnityVersionInfo(first, latest),
             description: new LocalizableResourceString("Description", resourceManager, typeof(T)));
         }
 
@@ -79,14 +79,19 @@ namespace UnityEngineAnalyzer
             return new string[] { Enum.GetName(typeof(UnityVersion), start), Enum.GetName(typeof(UnityVersion), end) };
         }
 
-        //TODO USE: (UnityVersion start, UnityVersion end) Tuple when updated to Net Standard 2.0
-        public static Tuple<UnityVersion, UnityVersion> GetVersion(DiagnosticDescriptor dc)
+        public static UnityVersionSpan GetVersion(DiagnosticDescriptor dc)
         {
             var list = dc.CustomTags.ToList();
+
+            if (list.Count < 2)
+            {
+                return new UnityVersionSpan(UnityVersion.NONE, UnityVersion.LATEST);
+            }
+
             var start = (UnityVersion)Enum.Parse(typeof(UnityVersion), list[0]);
             var end = (UnityVersion)Enum.Parse(typeof(UnityVersion), list[1]);
 
-            return Tuple.Create(start, end);
+            return new UnityVersionSpan(start, end);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticDescriptors.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticDescriptors.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
+using System;
+using System.Linq;
 using System.Resources;
 using UnityEngineAnalyzer.Animator;
 using UnityEngineAnalyzer.AOT;
@@ -16,7 +18,7 @@ using UnityEngineAnalyzer.StringMethods;
 
 namespace UnityEngineAnalyzer
 {
-    static class DiagnosticDescriptors
+    public static class DiagnosticDescriptors
     {
         public static readonly DiagnosticDescriptor DoNotUseOnGUI;
         public static readonly DiagnosticDescriptor DoNotUseStringMethods;
@@ -57,7 +59,7 @@ namespace UnityEngineAnalyzer
             CameraMainIsSlow = CreateDiagnosticDescriptor<CameraMainResource>(DiagnosticIDs.CameraMainIsSlow, DiagnosticCategories.GC, DiagnosticSeverity.Warning);
         }
 
-        private static DiagnosticDescriptor CreateDiagnosticDescriptor<T>(string id, string category, DiagnosticSeverity severity, bool isEnabledByDefault = true)
+        private static DiagnosticDescriptor CreateDiagnosticDescriptor<T>(string id, string category, DiagnosticSeverity severity, UnityVersion latest = UnityVersion.ALL, bool isEnabledByDefault = true)
         {
             var resourceManager = new ResourceManager(typeof(T));
 
@@ -68,7 +70,23 @@ namespace UnityEngineAnalyzer
             category: category,
             defaultSeverity: severity,
             isEnabledByDefault: isEnabledByDefault,
+            customTags: CreateUnityVersionInfo(latest, latest),
             description: new LocalizableResourceString("Description", resourceManager, typeof(T)));
+        }
+
+        private static string[] CreateUnityVersionInfo(UnityVersion start, UnityVersion end)
+        {
+            return new string[] { Enum.GetName(typeof(UnityVersion), start), Enum.GetName(typeof(UnityVersion), end) };
+        }
+
+        //TODO USE: (UnityVersion start, UnityVersion end) Tuple when updated to Net Standard 2.0
+        public static Tuple<UnityVersion, UnityVersion> GetVersion(DiagnosticDescriptor dc)
+        {
+            var list = dc.CustomTags.ToList();
+            var start = (UnityVersion)Enum.Parse(typeof(UnityVersion), list[0]);
+            var end = (UnityVersion)Enum.Parse(typeof(UnityVersion), list[1]);
+
+            return Tuple.Create(start, end);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticDescriptors.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticDescriptors.cs
@@ -40,23 +40,32 @@ namespace UnityEngineAnalyzer
 
         static DiagnosticDescriptors()
         {
+            //** UNITY **
+            
+            //GC
             DoNotUseOnGUI = CreateDiagnosticDescriptor<DoNotUseOnGUIResources>(DiagnosticIDs.DoNotUseOnGUI, DiagnosticCategories.GC, DiagnosticSeverity.Info);
             DoNotUseStringMethods = CreateDiagnosticDescriptor<DoNotUseStringMethodsResources>(DiagnosticIDs.DoNotUseStringMethods, DiagnosticCategories.GC, DiagnosticSeverity.Info);
             DoNotUseCoroutines = CreateDiagnosticDescriptor<DoNotUseCoroutinesResources>(DiagnosticIDs.DoNotUseCoroutines, DiagnosticCategories.GC, DiagnosticSeverity.Info);
-            EmptyMonoBehaviourMethod = CreateDiagnosticDescriptor<EmptyMonoBehaviourMethodsResources>(DiagnosticIDs.EmptyMonoBehaviourMethod, DiagnosticCategories.Miscellaneous, DiagnosticSeverity.Warning);
             UseCompareTag = CreateDiagnosticDescriptor<UseCompareTagResources>(DiagnosticIDs.UseCompareTag, DiagnosticCategories.GC, DiagnosticSeverity.Warning);
+            UseNonAllocMethods = CreateDiagnosticDescriptor<UseNonAllocMethodsResources>(DiagnosticIDs.PhysicsUseNonAllocMethods, DiagnosticCategories.GC, DiagnosticSeverity.Warning, UnityVersion.UNITY_5_3);
+            CameraMainIsSlow = CreateDiagnosticDescriptor<CameraMainResource>(DiagnosticIDs.CameraMainIsSlow, DiagnosticCategories.GC, DiagnosticSeverity.Warning);
+
+            //Performance
             DoNotUseFindMethodsInUpdate = CreateDiagnosticDescriptor<DoNotUseFindMethodsInUpdateResources>(DiagnosticIDs.DoNotUseFindMethodsInUpdate, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
             DoNotUseFindMethodsInUpdateRecursive = CreateDiagnosticDescriptor<DoNotUseFindMethodsInUpdateResources>(DiagnosticIDs.DoNotUseFindMethodsInUpdate, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
-            DoNotUseRemoting = CreateDiagnosticDescriptor<DoNotUseRemotingResources>(DiagnosticIDs.DoNotUseRemoting, DiagnosticCategories.AOT, DiagnosticSeverity.Info);
-            DoNotUseReflectionEmit = CreateDiagnosticDescriptor<DoNotUseReflectionEmitResources>(DiagnosticIDs.DoNotUseReflectionEmit, DiagnosticCategories.AOT, DiagnosticSeverity.Info);
-            TypeGetType = CreateDiagnosticDescriptor<TypeGetTypeResources>(DiagnosticIDs.TypeGetType, DiagnosticCategories.AOT, DiagnosticSeverity.Info);
-            DoNotUseForEachInUpdate = CreateDiagnosticDescriptor<DoNotUseForEachInUpdateResources>(DiagnosticIDs.DoNotUseForEachInUpdate, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
+            DoNotUseForEachInUpdate = CreateDiagnosticDescriptor<DoNotUseForEachInUpdateResources>(DiagnosticIDs.DoNotUseForEachInUpdate, DiagnosticCategories.Performance, DiagnosticSeverity.Warning, UnityVersion.UNITY_1_0, UnityVersion.UNITY_5_5);
             UnsealedDerivedClass = CreateDiagnosticDescriptor<UnsealedDerivedClassResources>(DiagnosticIDs.UnsealedDerivedClass, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
             InvokeFunctionMissing = CreateDiagnosticDescriptor<InvokeFunctionMissingResources>(DiagnosticIDs.InvokeFunctionMissing, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
             DoNotUseStateName = CreateDiagnosticDescriptor<DoNotUseStateNameResource>(DiagnosticIDs.DoNotUseStateNameInAnimator, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
             DoNotUseStringPropertyNames = CreateDiagnosticDescriptor<DoNotUseStringPropertyNamesResource>(DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial, DiagnosticCategories.Performance, DiagnosticSeverity.Warning);
-            UseNonAllocMethods = CreateDiagnosticDescriptor<UseNonAllocMethodsResources>(DiagnosticIDs.PhysicsUseNonAllocMethods, DiagnosticCategories.GC, DiagnosticSeverity.Warning, UnityVersion.UNITY_5_3);
-            CameraMainIsSlow = CreateDiagnosticDescriptor<CameraMainResource>(DiagnosticIDs.CameraMainIsSlow, DiagnosticCategories.GC, DiagnosticSeverity.Warning);
+
+            //Miscellaneous
+            EmptyMonoBehaviourMethod = CreateDiagnosticDescriptor<EmptyMonoBehaviourMethodsResources>(DiagnosticIDs.EmptyMonoBehaviourMethod, DiagnosticCategories.Miscellaneous, DiagnosticSeverity.Warning);
+
+            //** AOT **
+            DoNotUseRemoting = CreateDiagnosticDescriptor<DoNotUseRemotingResources>(DiagnosticIDs.DoNotUseRemoting, DiagnosticCategories.AOT, DiagnosticSeverity.Info);
+            DoNotUseReflectionEmit = CreateDiagnosticDescriptor<DoNotUseReflectionEmitResources>(DiagnosticIDs.DoNotUseReflectionEmit, DiagnosticCategories.AOT, DiagnosticSeverity.Info);
+            TypeGetType = CreateDiagnosticDescriptor<TypeGetTypeResources>(DiagnosticIDs.TypeGetType, DiagnosticCategories.AOT, DiagnosticSeverity.Info);
         }
 
         private static DiagnosticDescriptor CreateDiagnosticDescriptor<T>(string id, string category, DiagnosticSeverity severity, UnityVersion first = UnityVersion.UNITY_1_0, UnityVersion latest = UnityVersion.LATEST, bool isEnabledByDefault = true)

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticIDs.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer/DiagnosticIDs.cs
@@ -21,7 +21,5 @@ namespace UnityEngineAnalyzer
         public const string DoNotUseRemoting = "AOT0001";
         public const string DoNotUseReflectionEmit = "AOT0002";
         public const string TypeGetType = "AOT0003";
-
-        
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer/UnityEngineAnalyzer.csproj
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer/UnityEngineAnalyzer.csproj
@@ -134,6 +134,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>InvokeFunctionMissingResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="UnityVersions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Animator\DoNotUseStateNameResource.resx">

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer/UnityVersions.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer/UnityVersions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace UnityEngineAnalyzer
+{
+    public enum UnityVersion
+    {
+        ALL,
+        UNITY_1_0,
+        UNITY_2_0,
+        UNITY_3_0,
+        UNITY_3_5,
+        UNITY_4_0,
+        UNITY_4_1,
+        UNITY_4_2,
+        UNITY_4_3,
+        UNITY_4_4,
+        UNITY_4_5,
+        UNITY_4_6,
+        UNITY_4_7,
+        UNITY_5_0,
+        UNITY_5_1,
+        UNITY_5_2,
+        UNITY_5_3,
+        UNITY_5_4,
+        UNITY_5_5,
+        UNITY_5_6,
+        UNITY_2017_0,
+        UNITY_2017_1,
+        UNITY_2017_2,
+        UNITY_2017_3,
+    }
+}

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer/UnityVersions.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer/UnityVersions.cs
@@ -1,10 +1,20 @@
-﻿using System;
-
-namespace UnityEngineAnalyzer
+﻿namespace UnityEngineAnalyzer
 {
+    public class UnityVersionSpan
+    {
+        public UnityVersion First { get; set; }
+        public UnityVersion Last { get; set; }
+
+        public UnityVersionSpan (UnityVersion first, UnityVersion last)
+        {
+            First = first;
+            Last = last;
+        }
+    }
+
     public enum UnityVersion
     {
-        ALL,
+        NONE,
         UNITY_1_0,
         UNITY_2_0,
         UNITY_3_0,
@@ -28,5 +38,6 @@ namespace UnityEngineAnalyzer
         UNITY_2017_1,
         UNITY_2017_2,
         UNITY_2017_3,
+        LATEST,
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,9 @@ In order to use the Command Line Interface (CLI), download the latest release of
 1. (Optional) minimal severity for reports
 	* Use command `-s Info/Warning/Error` to defined used minimal severity for reporting
 	* Default is Warning
+1.	(Optional) Unity version for check
+	* Use command `-v UNITY_2017_1/UNITY_5_5/UNITY_4_0/...` to Unity version
+	* For default analyzer will try to find ProjectVersion.txt file and parse version automatically.
 
 Example:
 


### PR DESCRIPTION
Unity version check what was discussed in #15 
It will automatically try to resolve the Unity version from ProjectSettings.txt. Only works in Unity 5 >=.
Other wise it can be specified as -v Commandline argument.

I was first thinking of making UnityVersion enum as flags, but that would restrict us to only 32 unity versions?

Also I do not know if I missed any analyzers that would need this Unity version check.