### PR TITLE
Fix HasDiagnostic and NoDiagnostic test helpers.

### DIFF
--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/AOT/DoNotUseReflectionEmitAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/AOT/DoNotUseReflectionEmitAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.AOT;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Framework;
 using RoslynNUnitLight;
@@ -11,7 +10,6 @@ namespace UnityEngineAnalyzer.Test.AOT
     [TestFixture]
     sealed class DoNotUseReflectionEmitAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseReflectionEmitAnalyzer();
 
         [Test]

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/AOT/DoNotUseRemotingAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/AOT/DoNotUseRemotingAnalyzerTests.cs
@@ -1,6 +1,5 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.AOT;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Framework;
 using RoslynNUnitLight;
@@ -10,7 +9,6 @@ namespace UnityEngineAnalyzer.Test.AOT
     [TestFixture]
     sealed class DoNotUseRemotingAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseRemotingAnalyzer();
 
         [Test]

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/AOT/TypeGetTypeAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/AOT/TypeGetTypeAnalyzerTests.cs
@@ -11,7 +11,6 @@ namespace UnityEngineAnalyzer.Test.AOT
     [TestFixture]
     sealed class TypeGetTypeAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new TypeGetTypeAnalyzer();
 
         [Test]
@@ -28,22 +27,8 @@ class C : MonoBehaviour
         var theType =  [|Type.GetType("""")|];
     }
 }";
-            Document document;
-            TextSpan span;
 
-            var references = MetadataReferenceHelper.UsingUnityEngine;
-
-            if (TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, references, out document, out span))
-            {
-                this.HasDiagnostic(document, span, DiagnosticIDs.TypeGetType);
-            }
-            else
-            {
-                Assert.Fail("Could not load the Test code in the unit test");
-            }
-            
-
-
+            HasDiagnostic(code, DiagnosticIDs.TypeGetType);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Animator/DoNotUseStateNameAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Animator/DoNotUseStateNameAnalyzerTests.cs
@@ -12,7 +12,6 @@ namespace UnityEngineAnalyzer.Test.Animator
     [TestFixture]
     sealed class DoNotSetAnimatorParameterWithNameAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseStateNameAnalyzer();
 
         [Test]
@@ -31,11 +30,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStateNameInAnimator);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStateNameInAnimator);
         }
 
         [Test]
@@ -54,11 +49,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStateNameInAnimator);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStateNameInAnimator);
         }
 
         [Test]
@@ -77,11 +68,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStateNameInAnimator);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStateNameInAnimator);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Audio/AudioSourceAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Audio/AudioSourceAnalyzerTests.cs
@@ -11,7 +11,6 @@ namespace UnityEngineAnalyzer.Test.Audio
     [TestFixture]
     sealed class AudioSourceAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new AudioSourceAnalyzer();
 
         [Test]
@@ -30,11 +29,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.AudioSourceMuteUsesCPU);
+            HasDiagnostic(code, DiagnosticIDs.AudioSourceMuteUsesCPU);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Camera/CameraMainAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Camera/CameraMainAnalyzerTests.cs
@@ -1,8 +1,6 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.Camera;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
 
@@ -11,7 +9,6 @@ namespace UnityEngineAnalyzer.Test.Camera
     [TestFixture]
     sealed class CameraMainAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new CameraMainAnalyzer();
 
         [Test]
@@ -28,11 +25,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.CameraMainIsSlow);
+            HasDiagnostic(code, DiagnosticIDs.CameraMainIsSlow);
         }
 
         [Test]
@@ -49,11 +42,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.CameraMainIsSlow);
+            HasDiagnostic(code, DiagnosticIDs.CameraMainIsSlow);
         }
 
         [Test]
@@ -77,11 +66,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.CameraMainIsSlow);
+            HasDiagnostic(code, DiagnosticIDs.CameraMainIsSlow);
         }
 
         [Test]
@@ -98,11 +83,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            NoDiagnostic(document, DiagnosticIDs.CameraMainIsSlow);
+            NoDiagnostic(code, DiagnosticIDs.CameraMainIsSlow);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/CompareTag/UseCompareTagAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/CompareTag/UseCompareTagAnalyzerTests.cs
@@ -1,8 +1,6 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.CompareTag;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
 
@@ -11,7 +9,6 @@ namespace UnityEngineAnalyzer.Test.CompareTag
     [TestFixture]
     sealed class UseCompareTagAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new UseCompareTagAnalyzer();
 
         [Test]
@@ -28,11 +25,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.UseCompareTag);
+            HasDiagnostic(code, DiagnosticIDs.UseCompareTag);
         }
 
         [Test]
@@ -49,11 +42,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.UseCompareTag);
+            HasDiagnostic(code, DiagnosticIDs.UseCompareTag);
         }
 
         [Test]
@@ -73,11 +62,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.UseCompareTag);
+            HasDiagnostic(code, DiagnosticIDs.UseCompareTag);
         }
 
         [Test]
@@ -94,11 +79,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            NoDiagnostic(document, DiagnosticIDs.UseCompareTag);
+            NoDiagnostic(code, DiagnosticIDs.UseCompareTag);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Coroutines/DoNotUseCoroutinesAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Coroutines/DoNotUseCoroutinesAnalyzerTests.cs
@@ -1,8 +1,6 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.Coroutines;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
 
@@ -11,7 +9,6 @@ namespace UnityEngineAnalyzer.Test.Coroutines
     [TestFixture]
     sealed class DoNotUseCoroutinesAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseCoroutinesAnalyzer();
 
         [Test]
@@ -27,11 +24,7 @@ class C : MonoBehaviour
         [|StartCoroutine(""MyCoroutine"")|];
     }
 }";
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseCoroutines);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseCoroutines);
         }
 
         [Test]
@@ -50,11 +43,7 @@ class C : MonoBehaviour
         [|cc.StartCoroutine(""MyCoroutine"")|];
     }
 }";
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseCoroutines);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseCoroutines);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/EmptyMonoBehaviourMethods/EmptyMonoBehaviourMethodsAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/EmptyMonoBehaviourMethods/EmptyMonoBehaviourMethodsAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using NUnit.Framework;
 using RoslynNUnitLight;
 using Linty.Analyzers;
@@ -11,7 +9,6 @@ namespace UnityEngineAnalyzer.Test.EmptyMonoBehaviourMethods
     [TestFixture]
     sealed class EmptyMonoBehaviourMethodsAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new EmptyMonoBehaviourMethodsAnalyzer();
 
         [Test]
@@ -24,11 +21,8 @@ class C : MonoBehaviour
 {
     [|void Update() { }|]
 }";
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
 
-            HasDiagnostic(document, span, DiagnosticIDs.EmptyMonoBehaviourMethod);
+            HasDiagnostic(code, DiagnosticIDs.EmptyMonoBehaviourMethod);
         }
 
         [Test]
@@ -41,11 +35,8 @@ class C
 {
     [|void Update() { }|]
 }";
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
 
-            NoDiagnostic(document, DiagnosticIDs.EmptyMonoBehaviourMethod);
+            NoDiagnostic(code, DiagnosticIDs.EmptyMonoBehaviourMethod);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/FindMethodsInUpdate/DoNotUseFindMethodsInUpdateAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/FindMethodsInUpdate/DoNotUseFindMethodsInUpdateAnalyzerTests.cs
@@ -1,13 +1,8 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.FindMethodsInUpdate;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
-
-
-//using Microsoft.CodeAnalysis.Workspaces;
 
 namespace UnityEngineAnalyzer.Test.FindMethodsInUpdate
 {
@@ -15,7 +10,6 @@ namespace UnityEngineAnalyzer.Test.FindMethodsInUpdate
     sealed class DoNotUseFindMethodsInUpdateAnalyzerTests : AnalyzerTestFixture
     {
 
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseFindMethodsInUpdateAnalyzer();
 
         [Test]
@@ -34,18 +28,8 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
 
-            if (TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine,
-                out document, out span))
-            {
-                HasDiagnostic(document, span, DiagnosticIDs.DoNotUseFindMethodsInUpdate);
-            }
-            else
-            {
-                Assert.Fail("Could not load unit test code");
-            }
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseFindMethodsInUpdate);
         }
 
         [Test]
@@ -61,11 +45,8 @@ class C : MonoBehaviour
         [|GameObject.Find("")|];
     }
 }";
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
 
-            NoDiagnostic(document, DiagnosticIDs.EmptyMonoBehaviourMethod);
+            NoDiagnostic(code, DiagnosticIDs.EmptyMonoBehaviourMethod);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/ForEachInUpdate/DoNotUseForeachInUpdateAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/ForEachInUpdate/DoNotUseForeachInUpdateAnalyzerTests.cs
@@ -1,9 +1,6 @@
-﻿using System.Diagnostics;
-using Linty.Analyzers;
+﻿using Linty.Analyzers;
 using Linty.Analyzers.ForEachInUpdate;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
 
@@ -12,8 +9,6 @@ namespace UnityEngineAnalyzer.Test.ForEachInUpdate
     [TestFixture]
     sealed class DoNotUseForeachInUpdateAnalyzerTests : AnalyzerTestFixture
     {
-
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseForEachInUpdate();
 
         [Test]
@@ -35,20 +30,8 @@ class C : MonoBehaviour
         }
 }";
 
-            
 
-            Document document;
-            TextSpan span;
-
-            if (TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine,
-                out document, out span))
-            {
-                HasDiagnostic(document, span, DiagnosticIDs.DoNotUseForEachInUpdate);
-            }
-            else
-            {
-                Assert.Fail("Could not load unit test code");
-            }
+             HasDiagnostic(code, DiagnosticIDs.DoNotUseForEachInUpdate);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Material/DoNotUseStringPropertyNamesTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Material/DoNotUseStringPropertyNamesTests.cs
@@ -12,7 +12,6 @@ namespace UnityEngineAnalyzer.Test.Material
     [TestFixture]
     sealed class DoNotUseStringPropertyNamesAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseStringPropertyNamesAnalyzer();
 
         [Test]
@@ -31,11 +30,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial);
         }
 
         [Test]
@@ -54,11 +49,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial);
         }
 
         [Test]
@@ -77,11 +68,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringPropertyNamesInMaterial);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/OnGUI/DoNotUseOnGUIAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/OnGUI/DoNotUseOnGUIAnalyzerTests.cs
@@ -11,7 +11,6 @@ namespace UnityEngineAnalyzer.Test.OnGUI
     [TestFixture]
     sealed class DoNotUseOnGUIAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseOnGUIAnalyzer();
 
         [Test]
@@ -25,11 +24,7 @@ class C : MonoBehaviour
     void [|OnGUI|]() { }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseOnGUI);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseOnGUI);
         }
 
         [Test]

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Physics/UseNonAllocMethodsTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/Physics/UseNonAllocMethodsTests.cs
@@ -1,8 +1,6 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.Physics;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
 
@@ -12,7 +10,6 @@ namespace UnityEngineAnalyzer.Test.Animator
     [TestFixture]
     sealed class UseNonAllocMethodsTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new UseNonAllocMethodsAnalyzer();
 
         [Test]
@@ -30,11 +27,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.PhysicsUseNonAllocMethods);
+            HasDiagnostic(code, DiagnosticIDs.PhysicsUseNonAllocMethods);
         }
 
         [Test]
@@ -52,11 +45,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.PhysicsUseNonAllocMethods);
+            HasDiagnostic(code, DiagnosticIDs.PhysicsUseNonAllocMethods);
         }
 
         [Test]
@@ -73,11 +62,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.PhysicsUseNonAllocMethods);
+            HasDiagnostic(code, DiagnosticIDs.PhysicsUseNonAllocMethods);
         }
 
         [Test]
@@ -98,11 +83,7 @@ class C : MonoBehaviour
     }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.PhysicsUseNonAllocMethods);
+            HasDiagnostic(code, DiagnosticIDs.PhysicsUseNonAllocMethods);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/RoslynNUnitLight/AnalyzerTestFixture.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/RoslynNUnitLight/AnalyzerTestFixture.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
+using UnityEngineAnalyzer.Test;
 
 namespace RoslynNUnitLight
 {
@@ -12,14 +13,18 @@ namespace RoslynNUnitLight
     {
         protected abstract DiagnosticAnalyzer CreateAnalyzer();
 
+        protected override string LanguageName => LanguageNames.CSharp;
+
         protected void NoDiagnostic(string code, string diagnosticId)
         {
-            var document = TestHelpers.GetDocument(code, LanguageName);
+            Document document;
+            TextSpan span;
+            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
 
             NoDiagnostic(document, diagnosticId);
         }
 
-        protected void NoDiagnostic(Document document, string diagnosticId)
+        private void NoDiagnostic(Document document, string diagnosticId)
         {
             var diagnostics = GetDiagnostics(document);
 
@@ -30,12 +35,12 @@ namespace RoslynNUnitLight
         {
             Document document;
             TextSpan span;
-            Assert.That(TestHelpers.TryGetDocumentAndSpanFromMarkup(markupCode, LanguageName, out document, out span), Is.True);
+            Assert.That(TestHelpers.TryGetDocumentAndSpanFromMarkup(markupCode, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span), Is.True);
 
             HasDiagnostic(document, span, diagnosticId);
         }
 
-        protected void HasDiagnostic(Document document, TextSpan span, string diagnosticId)
+        private void HasDiagnostic(Document document, TextSpan span, string diagnosticId)
         {
             var diagnostics = GetDiagnostics(document);
             Assert.That(diagnostics.Length, Is.EqualTo(1));

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/StringMethods/DoNotUseStringMethodsAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/StringMethods/DoNotUseStringMethodsAnalyzerTests.cs
@@ -1,8 +1,6 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.StringMethods;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
 
@@ -11,7 +9,6 @@ namespace UnityEngineAnalyzer.Test.StringMethods
     [TestFixture]
     sealed class DoNotUseStringMethodsAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new DoNotUseStringMethodsAnalyzer();
 
         [Test]
@@ -25,11 +22,7 @@ class C : MonoBehaviour
     void Start() { [|SendMessage(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -43,11 +36,7 @@ class C : MonoBehaviour
     void Start() { [|SendMessageUpwards(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -61,11 +50,7 @@ class C : MonoBehaviour
     void Start() { [|BroadcastMessage(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -80,11 +65,7 @@ class C : MonoBehaviour
     void Start() { [|go.SendMessage(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -99,11 +80,7 @@ class C : MonoBehaviour
     void Start() { [|go.SendMessageUpwards(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -118,11 +95,7 @@ class C : MonoBehaviour
     void Start() { [|go.BroadcastMessage(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -139,11 +112,7 @@ class C : MonoBehaviour
     void Start() { [|cc.SendMessage(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -160,11 +129,7 @@ class C : MonoBehaviour
     void Start() { [|cc.SendMessageUpwards(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
 
         [Test]
@@ -181,11 +146,7 @@ class C : MonoBehaviour
     void Start() { [|cc.BroadcastMessage(string.Empty)|]; }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.DoNotUseStringMethods);
+            HasDiagnostic(code, DiagnosticIDs.DoNotUseStringMethods);
         }
     }
 }

--- a/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/StringMethods/InvokeFunctionMissingAnalyzerTests.cs
+++ b/UnityEngineAnalyzer/UnityEngineAnalyzer.Test/StringMethods/InvokeFunctionMissingAnalyzerTests.cs
@@ -1,8 +1,6 @@
 ﻿using Linty.Analyzers;
 using Linty.Analyzers.StringMethods;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using RoslynNUnitLight;
 
@@ -17,7 +15,6 @@ namespace UnityEngineAnalyzer.Test.StringMethods
     [TestFixture]
     sealed class InvokeFunctionMissingAnalyzerTests : AnalyzerTestFixture
     {
-        protected override string LanguageName => LanguageNames.CSharp;
         protected override DiagnosticAnalyzer CreateAnalyzer() => new InvokeFunctionMissingAnalyzer();
 
         [Test]
@@ -31,11 +28,7 @@ class C : MonoBehaviour
     void Start() { Invoke([|string.Empty|], 0f); }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.InvokeFunctionMissing);
+            HasDiagnostic(code, DiagnosticIDs.InvokeFunctionMissing);
         }
 
         [Test]
@@ -52,11 +45,7 @@ class C : MonoBehaviour
     void Start() { cc.Invoke([|string.Empty|], 0f); }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.InvokeFunctionMissing);
+            HasDiagnostic(code, DiagnosticIDs.InvokeFunctionMissing);
         }
 
         [Test]
@@ -70,11 +59,7 @@ class C : MonoBehaviour
     void Start() { InvokeRepeating([|string.Empty|], 0f, 0f); }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.InvokeFunctionMissing);
+            HasDiagnostic(code, DiagnosticIDs.InvokeFunctionMissing);
         }
 
         [Test]
@@ -91,11 +76,7 @@ class C : MonoBehaviour
     void Start() { cc.InvokeRepeating([|string.Empty|], 0f, 0f); }
 }";
 
-            Document document;
-            TextSpan span;
-            TestHelpers.TryGetDocumentAndSpanFromMarkup(code, LanguageName, MetadataReferenceHelper.UsingUnityEngine, out document, out span);
-
-            HasDiagnostic(document, span, DiagnosticIDs.InvokeFunctionMissing);
+            HasDiagnostic(code, DiagnosticIDs.InvokeFunctionMissing);
         }
     }
 }


### PR DESCRIPTION
HasDiagnostic and NoDiagnostic test helpers were not working since they were missing MetadataReferenceHelper.UsingUnityEngine or Language.Name could have been empty.
Also removed a lot of useless boilerplate code from tests.